### PR TITLE
Fix Sync in Ezirmin Log

### DIFF
--- a/src/ezirmin_log.ml
+++ b/src/ezirmin_log.ml
@@ -8,109 +8,6 @@ module Log(AO : Irmin.AO_MAKER)(SM : Irmin.S_MAKER)(V: Tc.S0) = struct
   module Path = Irmin.Path.String_list
   module K = Irmin.Hash.SHA1
 
-  module CR = struct
-
-    (*
-    * Type of a branch in the internal tree.
-    * 'key' is the Irmin key of the subtree pointed to the branch,
-    * 'min_depth' is the minimal depth of this subtree,
-    * 'max_depth' the maximal one.
-    *)
-    type branch = {
-      key : K.t;
-      min_depth : int;
-      max_depth : int;
-    }
-
-    module Branch = Tc.Biject
-      (Tc.Pair (Tc.Pair(K)(Tc.Int))(Tc.Int))
-      (struct
-        type t = branch
-        let to_t ((key, min_depth), max_depth) = {key; min_depth; max_depth}
-        let of_t {key; min_depth; max_depth} = ((key, min_depth), max_depth)
-      end)
-
-    (*
-    * Type of a node in the internal tree.
-    * 'ind' is the index of the node, which is equal to length of the left subtree
-    * 'len' is the length of the tree having this node as the root,
-    * 'left' is the branch pointed to the left subtree,
-    * 'right' the branch of the right one.
-    *)
-    type node = {
-      ind : int;
-      len : int;
-      left : branch;
-      right : branch;
-    }
-
-    module Node = Tc.Biject
-      (Tc.Pair(Tc.Pair(Tc.Int)(Tc.Int))(Tc.Pair(Branch)(Branch)))
-      (struct
-        type t = node
-        let to_t ((ind, len), (left, right)) =
-          {ind; len; left; right}
-        let of_t {ind; len; left; right} =
-          (ind, len), (left, right)
-      end)
-
-    (*
-    * Type of index, which is the accessor to the rope internal tree.
-    * 'length' is the length of the whole rope,
-    * 'root' is the root of the internal tree.
-    *)
-    type index = {
-      length : int;
-      root : K.t;
-    }
-
-    module Index = Tc.Biject
-      (Tc.Pair(Tc.Int)(K))
-      (struct
-        type t = index
-        let to_t (length, root) = {length; root}
-        let of_t {length; root} = (length, root)
-      end)
-
-    type t =
-      | Index of Index.t
-      | Node of Node.t
-      | Leaf of V.t
-    [@@deriving compare]
-
-    let equal a b =
-      Pervasives.compare a b = 0
-
-     let hash = Hashtbl.hash
-
-     let to_json = function
-       | Index i -> `O [ "index", Index.to_json i ]
-       | Node n -> `O [ "node", Node.to_json n ]
-       | Leaf v -> `O [ "leaf", V.to_json v ]
-
-     let of_json = function
-       | `O [ "index", j ] -> Index (Index.of_json j)
-       | `O [ "node", j ] -> Node (Node.of_json j)
-       | `O [ "leaf", j ] -> Leaf (V.of_json j)
-       | j -> Ezjsonm.parse_error j "C.of_json"
-
-    (* FIXME: slow *)
-    let to_string t = Ezjsonm.to_string (to_json t)
-    let of_string s = of_json (Ezjsonm.from_string s)
-    let write t buf =
-      let str = to_string t in
-      let len = String.length str in
-      Cstruct.blit_from_string str 0 buf 0 len;
-      Cstruct.shift buf len
-    let read buf =
-      Mstruct.get_string buf (Mstruct.length buf)
-      |> of_string
-    let size_of t =
-      let str = to_string t in
-      String.length str
-
-  end
-
   module type TIME = module type of Ptime
 
   module Time = struct
@@ -193,13 +90,17 @@ module Log(AO : Irmin.AO_MAKER)(SM : Irmin.S_MAKER)(V: Tc.S0) = struct
 
   module AORepo = Ezirmin_repo.Make(SM)(C)
 
-
   let updater = ref (fun k v -> failwith "r")
 
   module Store = struct
     module S = AO(K)(C)
     include S
-    let create () = create @@ Irmin_git.config ()
+
+    let config = ref None
+    let create () = 
+      match !config with
+      | None -> failwith "Log.S.create"
+      | Some c -> create c
 
     let add t v =
       S.add t v >>= fun k ->
@@ -285,7 +186,11 @@ module Make(AOM : Irmin.AO_MAKER)(S : Irmin.S_MAKER)(V:Tc.S0) : S
       let d1name: string = String.sub sk 0 2 in
       let d2name: string = String.sub sk 2 2 in
       let fname: string = String.sub sk 4 3 in
+      Printf.printf "%s \n %!" (d1name ^ d2name ^ fname);
       L.AORepo.Store.update (ib ("add " ^ fname)) [d1name; d2name; fname] v);
+    let module C = Irmin.Private.Conf in
+    let config = C.add C.empty C.root root in
+    L.Store.config := Some config;
     init ?root ?bare ()
 
   let append ?(message="update") t ~path e =

--- a/src/ezirmin_log.ml
+++ b/src/ezirmin_log.ml
@@ -186,7 +186,6 @@ module Make(AOM : Irmin.AO_MAKER)(S : Irmin.S_MAKER)(V:Tc.S0) : S
       let d1name: string = String.sub sk 0 2 in
       let d2name: string = String.sub sk 2 2 in
       let fname: string = String.sub sk 4 3 in
-      Printf.printf "%s \n %!" (d1name ^ d2name ^ fname);
       L.AORepo.Store.update (ib ("add " ^ fname)) [d1name; d2name; fname] v);
     let module C = Irmin.Private.Conf in
     let config = C.add C.empty C.root root in


### PR DESCRIPTION
This now uses an "internal" branch to force git to `pull` all log items. 
In an application using the log, a pull can be done using code along the lines of the following...
```OCaml
let ignore_lwt t = t >|= fun _ -> ()
let pull_mem remote_mem = Lwt.join [ignore_lwt @@ IrminLogMem.Sync.pull remote_mem internal_branch `Merge;
    ignore_lwt @@ IrminLogMem.Sync.pull remote_mem mempool_master_branch `Merge]
```